### PR TITLE
Check if ENTITY_TYPE exists

### DIFF
--- a/src/Generator/RenderTables.php
+++ b/src/Generator/RenderTables.php
@@ -93,7 +93,9 @@ final class RenderTables implements GeneratorInterface
         }
 
         if ($registry->getChildren($entity) !== []) {
-            $table->string(Mapper::ENTITY_TYPE, 32);
+            if (!$table->hasColumn(Mapper::ENTITY_TYPE)) {
+                $table->string(Mapper::ENTITY_TYPE, 32);
+            }
         }
 
         if (count($primaryKeys)) {


### PR DESCRIPTION
This will allow manually creating ENTITY_TYPE column and not have schema builder reset its size to a hard-coded value of 32.