### PR TITLE
Remove type consistency check for morphed relations

### DIFF
--- a/src/Relation/Traits/MorphTrait.php
+++ b/src/Relation/Traits/MorphTrait.php
@@ -60,10 +60,6 @@ trait MorphTrait
                 if ($key != $primaryKey) {
                     throw new RelationException('Inconsistent primary key reference (name)');
                 }
-
-                if ($field->getType() != $primaryField->getType()) {
-                    throw new RelationException('Inconsistent primary key reference (type)');
-                }
             }
         }
 

--- a/tests/Schema/Relation/Morphed/BelongsToMorphedRelationTest.php
+++ b/tests/Schema/Relation/Morphed/BelongsToMorphedRelationTest.php
@@ -53,26 +53,6 @@ abstract class BelongsToMorphedRelationTest extends BaseTest
     /**
      * @expectedException \Cycle\Schema\Exception\SchemaException
      */
-    public function testGenerateInconsistentType(): void
-    {
-        $e = MorphedTo::define();
-        $a = Author::define();
-        $p = Tag::define();
-
-        $r = new Registry($this->dbal);
-        $r->register($e)->linkTable($e, 'default', 'morphed');
-
-        $r->register($a)->linkTable($a, 'default', 'author');
-        $r->register($p)->linkTable($p, 'default', 'tag');
-
-        (new GenerateRelations(['belongsToMorphed' => new BelongsToMorphed()]))->run($r);
-
-        $this->assertInstanceOf(BelongsToMorphed::class, $r->getRelation($e, 'parent'));
-    }
-
-    /**
-     * @expectedException \Cycle\Schema\Exception\SchemaException
-     */
     public function testGenerateInconsistentName(): void
     {
         $e = MorphedTo::define();


### PR DESCRIPTION
This PR removes the type consistency check for morphed relation keys and while it will miss cases where types are obviously wrong, e.g accidental integer to varchar relation, it will however be more lenient on int to bigint which is very often an occasion with morphed relations.

Since morphs do not need foreign keys, I believe there's no need for such checks.