### PR TITLE
Checking for duplicated fields

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -130,17 +130,19 @@ final class Compiler
      */
     protected function renderColumns(Entity $entity): array
     {
-        // collect fields by row name
+        // Check field duplicates
         /** @var Field[][] $fieldGroups */
         $fieldGroups = [];
+        // Collect and group fields by column name
         foreach ($entity->getFields() as $name => $field) {
             $fieldGroups[$field->getColumn()][$name] = $field;
         }
         foreach ($fieldGroups as $fieldName => $fields) {
-            // Find duplicates
+            // We need duplicates only
             if (count($fields) === 1) {
                 continue;
             }
+            // Compare
             $comparator = new FieldComparator();
             foreach ($fields as $name => $field) {
                 $comparator->addField($name, $field);
@@ -149,7 +151,7 @@ final class Compiler
                 $comparator->compare();
             } catch (\Throwable $e) {
                 throw new Exception\CompilerException(
-                    "Error compiling the `{$entity->getRole()}` role.\n\n{$e->getMessage()}",
+                    sprintf("Error compiling the `%s` role.\n\n%s", $entity->getRole(), $e->getMessage()),
                     $e->getCode()
                 );
             }

--- a/src/Definition/Comparator/FieldComparator.php
+++ b/src/Definition/Comparator/FieldComparator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Cycle\Schema\Definition\Comparator;
@@ -13,7 +14,7 @@ final class FieldComparator
     /** @var Field[] */
     private $fields = [];
 
-    public function addField(string $key, Field $field): void
+    public function addField(string $key, Field $field): self
     {
         if ($this->columnName === null) {
             $this->columnName = $field->getColumn();
@@ -22,6 +23,7 @@ final class FieldComparator
             throw new InvalidArgumentException('The field comparator only accepts fields with the same column name.');
         }
         $this->fields[$key] = $field;
+        return $this;
     }
 
     public function compare(): void
@@ -56,7 +58,10 @@ final class FieldComparator
     private function compareProperties(): bool
     {
         $tuples = array_map(static function (Field $field): array {
-            return [$field->getType(), $field->isPrimary()];
+            return [
+                $field->getType(),
+                // $field->isPrimary(), // should not compared
+            ];
         }, $this->fields);
 
         // Compare options content

--- a/src/Definition/Comparator/FieldComparator.php
+++ b/src/Definition/Comparator/FieldComparator.php
@@ -1,0 +1,95 @@
+<?php
+declare(strict_types=1);
+
+namespace Cycle\Schema\Definition\Comparator;
+
+use Cycle\Schema\Definition\Field;
+use Exception;
+use InvalidArgumentException;
+
+final class FieldComparator
+{
+    private $columnName;
+    /** @var Field[] */
+    private $fields = [];
+
+    public function addField(string $key, Field $field): void
+    {
+        if ($this->columnName === null) {
+            $this->columnName = $field->getColumn();
+        }
+        if ($this->columnName !== $field->getColumn()) {
+            throw new InvalidArgumentException('The field comparator only accepts fields with the same column name.');
+        }
+        $this->fields[$key] = $field;
+    }
+
+    public function compare(): void
+    {
+        if (count($this->fields) <= 1) {
+            return;
+        }
+        // Check options
+        if (!$this->compareOptions() || !$this->compareProperties()) {
+            throw new Exception(
+                "Different definitions are specified for the `$this->columnName` column:"
+                . "\n\n{$this->generateErrorText()}"
+            );
+        }
+    }
+
+    private function generateErrorText(): string
+    {
+        $lines = [];
+        foreach ($this->fields as $key => $field) {
+            $primary = $field->isPrimary() ? ' primary' : '';
+            $line = sprintf("%s:\n  type=%s%s", $key, $field->getType(), $primary);
+            // Print options
+            foreach ($field->getOptions() as $optionName => $optionValue) {
+                $line .= " {$optionName}=" . var_export($optionValue, true);
+            }
+            $lines[] = $line;
+        }
+        return implode("\n\n", $lines);
+    }
+
+    private function compareProperties(): bool
+    {
+        $tuples = array_map(static function (Field $field): array {
+            return [$field->getType(), $field->isPrimary()];
+        }, $this->fields);
+
+        // Compare options content
+        $prototype = array_shift($tuples);
+        foreach ($tuples as $tuple) {
+            if (count(array_diff_assoc($prototype, $tuple)) > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private function compareOptions(): bool
+    {
+        // Collect fields options
+        $optionsSet = array_map(static function (Field $field): array {
+            return iterator_to_array($field->getOptions());
+        }, $this->fields);
+
+        // Compare options cont
+        $countResult = array_count_values(array_map('count', $optionsSet));
+        if (count($countResult) !== 1) {
+            return false;
+        }
+
+        // Compare options content
+        $prototype = array_shift($optionsSet);
+        foreach ($optionsSet as $options) {
+            if (count(array_diff_assoc($prototype, $options)) > 0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/Schema/Definition/Comparator/FieldComparatorTest.php
+++ b/tests/Schema/Definition/Comparator/FieldComparatorTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Schema\Tests\Definition\Comparator;
+
+use Cycle\Schema\Definition\Comparator\FieldComparator;
+use Cycle\Schema\Definition\Field;
+use PHPUnit\Framework\TestCase;
+
+final class FieldComparatorTest extends TestCase
+{
+    protected const EXCEPTION_MESSAGE_PREFIX = '/Different definitions are specified.*/';
+
+    public function testCompareSameObject(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+        $bar = $foo;
+
+        $this->createComparator()
+            ->addField('foo', $foo)
+            ->addField('bar', $bar)
+            ->compare();
+
+        // No exception
+        $this->assertTrue(true);
+    }
+
+    public function testCompareMoreObjects(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+        $bar = $foo;
+        $baz = clone $foo;
+        $zoo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+        $bravo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+
+        $this->createComparator()
+            ->addField('foo', $foo)
+            ->addField('bar', $bar)
+            ->addField('baz', $baz)
+            ->addField('zoo', $zoo)
+            ->addField('bravo', $bravo)
+            ->compare();
+
+        // No exception
+        $this->assertTrue(true);
+    }
+
+    public function testCompareWithoutFields(): void
+    {
+        $this->createComparator()->compare();
+
+        // No exception
+        $this->assertTrue(true);
+    }
+
+    public function testDifferentTypes(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+        $bar = $this->createField('foo', 'bigInteger', ['nullable' => true, 'default' => null]);
+        $comparator = $this->createComparator()
+            ->addField('foo', $foo)
+            ->addField('bar', $bar);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches(self::EXCEPTION_MESSAGE_PREFIX);
+
+        $comparator->compare();
+    }
+
+    public function testDifferentOptions(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+        $bar = $this->createField('foo', 'integer', ['nullable' => true, 'default' => 42]);
+        $comparator = $this->createComparator()
+            ->addField('foo', $foo)
+            ->addField('bar', $bar);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches(self::EXCEPTION_MESSAGE_PREFIX);
+
+        $comparator->compare();
+    }
+
+    public function testDifferentOptionsItemsCount(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['default' => null]);
+        $bar = $this->createField('foo', 'integer', ['nullable' => true, 'default' => null]);
+        $comparator = $this->createComparator()
+            ->addField('foo', $foo)
+            ->addField('bar', $bar);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessageMatches(self::EXCEPTION_MESSAGE_PREFIX);
+
+        $comparator->compare();
+    }
+
+    public function testDifferentPrimaryFlag(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => 42])->setPrimary(true);
+        $bar = $this->createField('foo', 'integer', ['nullable' => true, 'default' => 42])->setPrimary(false);
+        $this->createComparator()
+            ->addField('foo', $foo)
+            ->addField('bar', $bar)
+            ->compare();
+
+        // No exception
+        $this->assertTrue(true);
+    }
+
+    public function testDifferentColumnName(): void
+    {
+        $foo = $this->createField('foo', 'integer', ['nullable' => true, 'default' => 42]);
+        $bar = $this->createField('bar', 'integer', ['nullable' => true, 'default' => 42]);
+        $comparator = $this->createComparator()
+            ->addField('foo', $foo);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The field comparator only accepts fields with the same column name.');
+
+        $comparator->addField('bar', $bar);
+    }
+
+    private function createComparator(): FieldComparator
+    {
+        return new FieldComparator();
+    }
+
+    private function createField(string $column, string $type = 'integer', array $options = []): Field
+    {
+        $field = (new Field())
+            ->setType($type)
+            ->setColumn($column);
+        // Apply options
+        $optionsMap = $field->getOptions();
+        foreach ($options as $key => $value) {
+            $optionsMap->set($key, $value);
+        }
+        return $field;
+    }
+}

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   sqlserver:
-    image: microsoft/mssql-server-linux
+    image: mcr.microsoft.com/mssql/server:2019-latest
     ports:
       - "11433:1433"
     environment:
@@ -11,7 +11,7 @@ services:
 
   mysql_latest:
     image: mysql:latest
-    restart: 'always'
+    restart: always
     command: --default-authentication-plugin=mysql_native_password
     ports:
       - "13306:3306"


### PR DESCRIPTION
When the schema is compiled, multiple fields can be defined for the same entity that refer to the same table column.
Example: https://github.com/cycle/orm/issues/164

An exception will now be thrown if different definitions are found for the same column.

![image](https://user-images.githubusercontent.com/4152481/111673676-460b0d00-882c-11eb-8d2b-c5ed0acc12f4.png)
