### PR TITLE
Fix schema compute for STI children

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -58,12 +58,9 @@ final class Compiler
         }
 
         foreach ($registry->getIterator() as $entity) {
-            if (!$entity->hasPrimaryKey()) {
-                // incomplete entity, skip
-                continue;
+            if ($entity->hasPrimaryKey() || $entity->isChildOfSingleTableInheritance()) {
+                $this->compute($registry, $entity);
             }
-
-            $this->compute($registry, $entity);
         }
 
         return $this->result;

--- a/tests/Schema/Definition/Inheritance/SingleTableInheritanceTest.php
+++ b/tests/Schema/Definition/Inheritance/SingleTableInheritanceTest.php
@@ -27,7 +27,6 @@ class SingleTableInheritanceTest extends TestCase
 
         $author = new Entity();
         $author->setRole('author')->setClass(Author::class);
-        $author->getFields()->set('id', (new Field())->setType('primary')->setColumn('id'));
         $author->markAsChildOfSingleTableInheritance(User::class);
 
         $user = new Entity();

--- a/tests/Schema/Definition/Inheritance/SingleTableInheritanceTest.php
+++ b/tests/Schema/Definition/Inheritance/SingleTableInheritanceTest.php
@@ -51,6 +51,39 @@ class SingleTableInheritanceTest extends TestCase
         $this->assertSame([SchemaInterface::ENTITY => Author::class], $schema['author']);
     }
 
+    public function testSingleTableWithExplicitPkShouldBeAddedToSchema()
+    {
+        $r = new Registry(
+            $this->createMock(DatabaseProviderInterface::class)
+        );
+
+        $author = new Entity();
+        $author->setRole('author')->setClass(Author::class);
+        $author->getFields()->set('id', (new Field())->setType('primary')->setColumn('id'));
+        $author->markAsChildOfSingleTableInheritance(User::class);
+
+        $user = new Entity();
+        $user->setRole('user')->setClass(User::class);
+        $user->setInheritance($inheritance = new SingleTable());
+
+        $inheritance->setDiscriminator('type');
+        $inheritance->addChild('foo', 'bar');
+        $inheritance->addChild('author', 'author');
+
+        $user->getFields()->set('id', (new Field())->setType('primary')->setColumn('id'));
+        $user->getFields()->set('type', (new Field())->setType('string')->setColumn('type'));
+
+        $r->register($user);
+        $r->register($author);
+
+        $schema = (new Compiler())->compile($r);
+
+        $this->assertSame(['foo' => 'bar', 'author' => 'author'], $schema['user'][SchemaInterface::CHILDREN]);
+        $this->assertSame('type', $schema['user'][SchemaInterface::DISCRIMINATOR]);
+
+        $this->assertSame([SchemaInterface::ENTITY => Author::class], $schema['author']);
+    }
+
     public function testSingleTableWithoutDiscriminatorColumnShouldThrowAnException()
     {
         $this->expectException(DiscriminatorColumnNotPresentException::class);


### PR DESCRIPTION
This PR fixes the bug in Compiler that lead to all STI children entities being discarded from runtime schema.

It also fixes the repro test that had explicitly set primary keys on STI children which is not how it's done in annotated classes. STI children usually extend parent entity class and doesn't declare their own primary keys.