### PR TITLE
Add ability to avoid Index creation when ForeignKey is created

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "require": {
     "php": ">=8.0",
     "cycle/orm": "^2.0",
-    "cycle/database": "^2.4",
+    "cycle/database": "^2.5",
     "yiisoft/friendly-exception": "^1.1"
   },
   "require-dev": {

--- a/src/Relation/BelongsTo.php
+++ b/src/Relation/BelongsTo.php
@@ -83,7 +83,14 @@ final class BelongsTo extends RelationSchema implements InversableInterface
         }
 
         if ($this->options->get(self::FK_CREATE)) {
-            $this->createForeignCompositeKey($registry, $target, $source, $outerFields, $innerFields);
+            $this->createForeignCompositeKey(
+                $registry,
+                $target,
+                $source,
+                $outerFields,
+                $innerFields,
+                $this->options->get(self::INDEX_CREATE)
+            );
         }
     }
 

--- a/src/Relation/HasMany.php
+++ b/src/Relation/HasMany.php
@@ -92,7 +92,14 @@ final class HasMany extends RelationSchema implements InversableInterface
         }
 
         if ($this->options->get(self::FK_CREATE)) {
-            $this->createForeignCompositeKey($registry, $source, $target, $innerFields, $outerFields);
+            $this->createForeignCompositeKey(
+                $registry,
+                $source,
+                $target,
+                $innerFields,
+                $outerFields,
+                $this->options->get(self::INDEX_CREATE)
+            );
         }
     }
 

--- a/src/Relation/HasOne.php
+++ b/src/Relation/HasOne.php
@@ -83,7 +83,14 @@ final class HasOne extends RelationSchema implements InversableInterface
         }
 
         if ($this->options->get(self::FK_CREATE)) {
-            $this->createForeignCompositeKey($registry, $source, $target, $innerFields, $outerFields);
+            $this->createForeignCompositeKey(
+                $registry,
+                $source,
+                $target,
+                $innerFields,
+                $outerFields,
+                $this->options->get(self::INDEX_CREATE)
+            );
         }
     }
 

--- a/src/Relation/ManyToMany.php
+++ b/src/Relation/ManyToMany.php
@@ -149,8 +149,22 @@ final class ManyToMany extends RelationSchema implements InversableInterface
         }
 
         if ($this->options->get(self::FK_CREATE)) {
-            $this->createForeignCompositeKey($registry, $source, $through, $sourceFields, $throughSourceFields);
-            $this->createForeignCompositeKey($registry, $target, $through, $targetFields, $throughTargetFields);
+            $this->createForeignCompositeKey(
+                $registry,
+                $source,
+                $through,
+                $sourceFields,
+                $throughSourceFields,
+                $this->options->get(self::INDEX_CREATE)
+            );
+            $this->createForeignCompositeKey(
+                $registry,
+                $target,
+                $through,
+                $targetFields,
+                $throughTargetFields,
+                $this->options->get(self::INDEX_CREATE)
+            );
         }
     }
 

--- a/src/Relation/RefersTo.php
+++ b/src/Relation/RefersTo.php
@@ -77,7 +77,14 @@ final class RefersTo extends RelationSchema
         }
 
         if ($this->options->get(self::FK_CREATE)) {
-            $this->createForeignCompositeKey($registry, $target, $source, $outerFields, $innerFields);
+            $this->createForeignCompositeKey(
+                $registry,
+                $target,
+                $source,
+                $outerFields,
+                $innerFields,
+                $this->options->get(self::INDEX_CREATE)
+            );
         }
     }
 }

--- a/src/Relation/Traits/ForeignKeyTrait.php
+++ b/src/Relation/Traits/ForeignKeyTrait.php
@@ -21,7 +21,8 @@ trait ForeignKeyTrait
         Entity $source,
         Entity $target,
         Field $innerField,
-        Field $outerField
+        Field $outerField,
+        bool $indexCreate = true
     ): void {
         if ($registry->getDatabase($source) !== $registry->getDatabase($target)) {
             return;
@@ -30,7 +31,7 @@ trait ForeignKeyTrait
         $outerFields = (new FieldMap())->set($outerField->getColumn(), $outerField);
         $innerFields = (new FieldMap())->set($innerField->getColumn(), $innerField);
 
-        $this->createForeignCompositeKey($registry, $source, $target, $outerFields, $innerFields);
+        $this->createForeignCompositeKey($registry, $source, $target, $outerFields, $innerFields, $indexCreate);
     }
 
     /**
@@ -42,7 +43,8 @@ trait ForeignKeyTrait
         Entity $source,
         Entity $target,
         FieldMap $innerFields,
-        FieldMap $outerFields
+        FieldMap $outerFields,
+        bool $indexCreate = true
     ): void {
         if ($registry->getDatabase($source) !== $registry->getDatabase($target)) {
             return;
@@ -50,7 +52,7 @@ trait ForeignKeyTrait
 
         $fkAction = $this->getOptions()->get(RelationSchema::FK_ACTION);
         $registry->getTableSchema($target)
-            ->foreignKey($outerFields->getColumnNames())
+            ->foreignKey($outerFields->getColumnNames(), $indexCreate)
             ->references($registry->getTable($source), $innerFields->getColumnNames())
             ->onUpdate($fkAction)
             ->onDelete($this->getOptions()->get(RelationSchema::FK_ON_DELETE) ?? $fkAction);

--- a/tests/Schema/Driver/Postgres/BelongsToRelationTest.php
+++ b/tests/Schema/Driver/Postgres/BelongsToRelationTest.php
@@ -4,9 +4,40 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\Postgres;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\BelongsTo;
+use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Relation\BelongsToRelationTest as BaseTest;
 
 class BelongsToRelationTest extends BaseTest
 {
     public const DRIVER = 'postgres';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Post::define();
+        $u = Author::define();
+
+        $e->getRelations()->get('author')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'post');
+        $r->register($u)->linkTable($u, 'default', 'author');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['belongsTo' => new BelongsTo()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('post');
+        $this->assertFalse($table->hasIndex(['author_p_id']));
+    }
 }

--- a/tests/Schema/Driver/Postgres/HasManyRelationTest.php
+++ b/tests/Schema/Driver/Postgres/HasManyRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\Postgres;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\HasMany;
+use Cycle\Schema\Tests\Fixtures\Plain;
+use Cycle\Schema\Tests\Fixtures\User;
 use Cycle\Schema\Tests\Relation\HasManyRelationTest as BaseTest;
 
 class HasManyRelationTest extends BaseTest
 {
     public const DRIVER = 'postgres';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->setType('hasMany');
+        $u->getRelations()->get('plain')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasMany' => new HasMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertFalse($table->hasIndex(['user_p_id']));
+    }
 }

--- a/tests/Schema/Driver/Postgres/HasOneRelationTest.php
+++ b/tests/Schema/Driver/Postgres/HasOneRelationTest.php
@@ -4,9 +4,40 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\Postgres;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\HasOne;
+use Cycle\Schema\Tests\Fixtures\Plain;
+use Cycle\Schema\Tests\Fixtures\User;
 use Cycle\Schema\Tests\Relation\HasOneRelationTest as BaseTest;
 
 class HasOneRelationTest extends BaseTest
 {
     public const DRIVER = 'postgres';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasOne' => new HasOne()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertFalse($table->hasIndex(['user_p_id']));
+    }
 }

--- a/tests/Schema/Driver/Postgres/ManyToManyRelationTest.php
+++ b/tests/Schema/Driver/Postgres/ManyToManyRelationTest.php
@@ -4,9 +4,53 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\Postgres;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Definition\Relation as RelationDefinition;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\ManyToMany;
+use Cycle\Schema\Tests\Fixtures\Post;
+use Cycle\Schema\Tests\Fixtures\Tag;
+use Cycle\Schema\Tests\Fixtures\TagContext;
 use Cycle\Schema\Tests\Relation\ManyToManyRelationTest as BaseTest;
 
 class ManyToManyRelationTest extends BaseTest
 {
     public const DRIVER = 'postgres';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $post = Post::define();
+        $tag = Tag::define();
+        $tagContext = TagContext::define();
+
+        $post->getRelations()->remove('author');
+
+        $post->getRelations()->set('tags', new RelationDefinition());
+        $post->getRelations()->get('tags')
+            ->setType('manyToMany')
+            ->setTarget('tag')
+            ->getOptions()
+            ->set('through', 'tagContext')
+            ->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($post)->linkTable($post, 'default', 'post');
+        $r->register($tag)->linkTable($tag, 'default', 'tag');
+        $r->register($tagContext)->linkTable($tagContext, 'default', 'tag_context');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['manyToMany' => new ManyToMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('tag_context');
+        $this->assertFalse($table->hasIndex(['tag_p_id']));
+        $this->assertFalse($table->hasIndex(['post_p_id']));
+    }
 }

--- a/tests/Schema/Driver/Postgres/RefersToRelationTest.php
+++ b/tests/Schema/Driver/Postgres/RefersToRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\Postgres;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\RefersTo;
+use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Relation\RefersToRelationTest as BaseTest;
 
 class RefersToRelationTest extends BaseTest
 {
     public const DRIVER = 'postgres';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Post::define();
+        $u = Author::define();
+
+        $e->getRelations()->get('author')->setType('refersTo');
+        $e->getRelations()->get('author')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'post');
+        $r->register($u)->linkTable($u, 'default', 'author');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['refersTo' => new RefersTo()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('post');
+        $this->assertFalse($table->hasIndex(['author_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLServer/BelongsToRelationTest.php
+++ b/tests/Schema/Driver/SQLServer/BelongsToRelationTest.php
@@ -4,9 +4,40 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLServer;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\BelongsTo;
+use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Relation\BelongsToRelationTest as BaseTest;
 
 class BelongsToRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlserver';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Post::define();
+        $u = Author::define();
+
+        $e->getRelations()->get('author')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'post');
+        $r->register($u)->linkTable($u, 'default', 'author');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['belongsTo' => new BelongsTo()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('post');
+        $this->assertFalse($table->hasIndex(['author_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLServer/HasManyRelationTest.php
+++ b/tests/Schema/Driver/SQLServer/HasManyRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLServer;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\HasMany;
+use Cycle\Schema\Tests\Fixtures\Plain;
+use Cycle\Schema\Tests\Fixtures\User;
 use Cycle\Schema\Tests\Relation\HasManyRelationTest as BaseTest;
 
 class HasManyRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlserver';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->setType('hasMany');
+        $u->getRelations()->get('plain')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasMany' => new HasMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertFalse($table->hasIndex(['user_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLServer/HasOneRelationTest.php
+++ b/tests/Schema/Driver/SQLServer/HasOneRelationTest.php
@@ -4,9 +4,40 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLServer;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\HasOne;
+use Cycle\Schema\Tests\Fixtures\Plain;
+use Cycle\Schema\Tests\Fixtures\User;
 use Cycle\Schema\Tests\Relation\HasOneRelationTest as BaseTest;
 
 class HasOneRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlserver';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasOne' => new HasOne()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertFalse($table->hasIndex(['user_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLServer/ManyToManyRelationTest.php
+++ b/tests/Schema/Driver/SQLServer/ManyToManyRelationTest.php
@@ -4,9 +4,53 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLServer;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Definition\Relation as RelationDefinition;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\ManyToMany;
+use Cycle\Schema\Tests\Fixtures\Post;
+use Cycle\Schema\Tests\Fixtures\Tag;
+use Cycle\Schema\Tests\Fixtures\TagContext;
 use Cycle\Schema\Tests\Relation\ManyToManyRelationTest as BaseTest;
 
 class ManyToManyRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlserver';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $post = Post::define();
+        $tag = Tag::define();
+        $tagContext = TagContext::define();
+
+        $post->getRelations()->remove('author');
+
+        $post->getRelations()->set('tags', new RelationDefinition());
+        $post->getRelations()->get('tags')
+            ->setType('manyToMany')
+            ->setTarget('tag')
+            ->getOptions()
+            ->set('through', 'tagContext')
+            ->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($post)->linkTable($post, 'default', 'post');
+        $r->register($tag)->linkTable($tag, 'default', 'tag');
+        $r->register($tagContext)->linkTable($tagContext, 'default', 'tag_context');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['manyToMany' => new ManyToMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('tag_context');
+        $this->assertFalse($table->hasIndex(['tag_p_id']));
+        $this->assertFalse($table->hasIndex(['post_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLServer/RefersToRelationTest.php
+++ b/tests/Schema/Driver/SQLServer/RefersToRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLServer;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\RefersTo;
+use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Relation\RefersToRelationTest as BaseTest;
 
 class RefersToRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlserver';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Post::define();
+        $u = Author::define();
+
+        $e->getRelations()->get('author')->setType('refersTo');
+        $e->getRelations()->get('author')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'post');
+        $r->register($u)->linkTable($u, 'default', 'author');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['refersTo' => new RefersTo()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('post');
+        $this->assertFalse($table->hasIndex(['author_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLite/BelongsToRelationTest.php
+++ b/tests/Schema/Driver/SQLite/BelongsToRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLite;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\BelongsTo;
+use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Relation\BelongsToRelationTest as BaseTest;
 
 class BelongsToRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlite';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Post::define();
+        $u = Author::define();
+
+        $e->getRelations()->get('author')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'post');
+        $r->register($u)->linkTable($u, 'default', 'author');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['belongsTo' => new BelongsTo()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        // RENDER!
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('post');
+        $this->assertFalse($table->hasIndex(['author_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLite/BelongsToRelationTest.php
+++ b/tests/Schema/Driver/SQLite/BelongsToRelationTest.php
@@ -35,7 +35,6 @@ class BelongsToRelationTest extends BaseTest
             new RenderRelations(),
         ]);
 
-        // RENDER!
         $t->getReflector()->run();
 
         $table = $this->getDriver()->getSchema('post');

--- a/tests/Schema/Driver/SQLite/HasManyRelationTest.php
+++ b/tests/Schema/Driver/SQLite/HasManyRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLite;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\HasMany;
+use Cycle\Schema\Tests\Fixtures\Plain;
+use Cycle\Schema\Tests\Fixtures\User;
 use Cycle\Schema\Tests\Relation\HasManyRelationTest as BaseTest;
 
 class HasManyRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlite';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->setType('hasMany');
+        $u->getRelations()->get('plain')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasMany' => new HasMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertFalse($table->hasIndex(['user_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLite/HasOneRelationTest.php
+++ b/tests/Schema/Driver/SQLite/HasOneRelationTest.php
@@ -4,9 +4,40 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLite;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\HasOne;
+use Cycle\Schema\Tests\Fixtures\Plain;
+use Cycle\Schema\Tests\Fixtures\User;
 use Cycle\Schema\Tests\Relation\HasOneRelationTest as BaseTest;
 
 class HasOneRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlite';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasOne' => new HasOne()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertFalse($table->hasIndex(['user_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLite/ManyToManyRelationTest.php
+++ b/tests/Schema/Driver/SQLite/ManyToManyRelationTest.php
@@ -4,9 +4,53 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLite;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Definition\Relation as RelationDefinition;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\ManyToMany;
+use Cycle\Schema\Tests\Fixtures\Post;
+use Cycle\Schema\Tests\Fixtures\Tag;
+use Cycle\Schema\Tests\Fixtures\TagContext;
 use Cycle\Schema\Tests\Relation\ManyToManyRelationTest as BaseTest;
 
 class ManyToManyRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlite';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $post = Post::define();
+        $tag = Tag::define();
+        $tagContext = TagContext::define();
+
+        $post->getRelations()->remove('author');
+
+        $post->getRelations()->set('tags', new RelationDefinition());
+        $post->getRelations()->get('tags')
+            ->setType('manyToMany')
+            ->setTarget('tag')
+            ->getOptions()
+            ->set('through', 'tagContext')
+            ->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($post)->linkTable($post, 'default', 'post');
+        $r->register($tag)->linkTable($tag, 'default', 'tag');
+        $r->register($tagContext)->linkTable($tagContext, 'default', 'tag_context');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['manyToMany' => new ManyToMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('tag_context');
+        $this->assertFalse($table->hasIndex(['tag_p_id']));
+        $this->assertFalse($table->hasIndex(['post_p_id']));
+    }
 }

--- a/tests/Schema/Driver/SQLite/RefersToRelationTest.php
+++ b/tests/Schema/Driver/SQLite/RefersToRelationTest.php
@@ -4,9 +4,41 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests\Driver\SQLite;
 
+use Cycle\Schema\Compiler;
+use Cycle\Schema\Generator\GenerateRelations;
+use Cycle\Schema\Generator\RenderRelations;
+use Cycle\Schema\Generator\RenderTables;
+use Cycle\Schema\Registry;
+use Cycle\Schema\Relation\RefersTo;
+use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Relation\RefersToRelationTest as BaseTest;
 
 class RefersToRelationTest extends BaseTest
 {
     public const DRIVER = 'sqlite';
+
+    public function testRenderWithoutIndex(): void
+    {
+        $e = Post::define();
+        $u = Author::define();
+
+        $e->getRelations()->get('author')->setType('refersTo');
+        $e->getRelations()->get('author')->getOptions()->set('indexCreate', false);
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'post');
+        $r->register($u)->linkTable($u, 'default', 'author');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['refersTo' => new RefersTo()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('post');
+        $this->assertFalse($table->hasIndex(['author_p_id']));
+    }
 }

--- a/tests/Schema/RegistryTest.php
+++ b/tests/Schema/RegistryTest.php
@@ -33,7 +33,7 @@ abstract class RegistryTest extends BaseTest
     public function testDuplicateRoleShouldThrowAnException(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Duplicate entity `user`');
+        $this->expectExceptionMessage('Duplicate entity `user`');
 
         $r = new Registry($this->dbal);
 

--- a/tests/Schema/Relation/BelongsToRelationCompositePKTest.php
+++ b/tests/Schema/Relation/BelongsToRelationCompositePKTest.php
@@ -63,7 +63,7 @@ abstract class BelongsToRelationCompositePKTest extends BaseTest
     public function testInconsistentAmountOfPKsShouldThrowAndException(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Inconsistent amount of related fields. '
+        $this->expectExceptionMessage('Inconsistent amount of related fields. '
             . 'Source entity: `author`; keys: `id`, `slug`. Target entity: `post`; keys: `parent_id`.');
 
         $e = Post::defineCompositePK();

--- a/tests/Schema/Relation/EmbeddedTest.php
+++ b/tests/Schema/Relation/EmbeddedTest.php
@@ -43,7 +43,7 @@ abstract class EmbeddedTest extends BaseTest
     public function testThrowAnExceptionWhenPkNotDefinedInSource(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Entity `composite` must have defined primary key');
+        $this->expectExceptionMessage('Entity `composite` must have defined primary key');
 
         $c = Composite::defineWithoutPk();
         $e = EmbeddedEntity::define();

--- a/tests/Schema/Relation/HasManyRelationCompositePKTest.php
+++ b/tests/Schema/Relation/HasManyRelationCompositePKTest.php
@@ -67,7 +67,7 @@ abstract class HasManyRelationCompositePKTest extends BaseTest
     public function testInconsistentAmountOfPKsShouldThrowAndException(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Inconsistent amount of related fields. '
+        $this->expectExceptionMessage('Inconsistent amount of related fields. '
             . 'Source entity: `user`; keys: `id`, `slug`. Target entity: `plain`; keys: `parent_id`.');
 
         $e = Plain::defineCompositePK();

--- a/tests/Schema/Relation/HasManyRelationTest.php
+++ b/tests/Schema/Relation/HasManyRelationTest.php
@@ -43,7 +43,7 @@ abstract class HasManyRelationTest extends BaseTest
     public function testThrowAnExceptionWhenPkNotDefinedInSource(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Entity `plain` must have defined primary key');
+        $this->expectExceptionMessage('Entity `plain` must have defined primary key');
 
         $e = Plain::defineWithoutPK();
         $u = User::define();
@@ -60,7 +60,7 @@ abstract class HasManyRelationTest extends BaseTest
     public function testThrowAnExceptionWhenPkNotDefinedInTarget(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Entity `user` must have defined primary key');
+        $this->expectExceptionMessage('Entity `user` must have defined primary key');
 
         $e = Plain::define();
         $u = User::defineWithoutPK();
@@ -280,5 +280,28 @@ abstract class HasManyRelationTest extends BaseTest
             'user_p_id',
             $schema['plain'][Schema::RELATIONS]['user'][Relation::SCHEMA][Relation::INNER_KEY]
         );
+    }
+
+    public function testRenderWithIndex(): void
+    {
+        $e = Plain::define();
+        $u = User::define();
+
+        $u->getRelations()->get('plain')->setType('hasMany');
+
+        $r = new Registry($this->dbal);
+        $r->register($e)->linkTable($e, 'default', 'plain');
+        $r->register($u)->linkTable($u, 'default', 'user');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['hasMany' => new HasMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('plain');
+        $this->assertTrue($table->hasIndex(['user_p_id']));
     }
 }

--- a/tests/Schema/Relation/HasOneRelationCompositePKTest.php
+++ b/tests/Schema/Relation/HasOneRelationCompositePKTest.php
@@ -121,7 +121,7 @@ abstract class HasOneRelationCompositePKTest extends BaseTest
     public function testInconsistentAmountOfPKsShouldThrowAndException(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Inconsistent amount of related fields. '
+        $this->expectExceptionMessage('Inconsistent amount of related fields. '
             . 'Source entity: `user`; keys: `id`, `slug`. Target entity: `plain`; keys: `parent_id`.');
 
         $e = Plain::defineCompositePK();

--- a/tests/Schema/Relation/ManyToManyRelationTest.php
+++ b/tests/Schema/Relation/ManyToManyRelationTest.php
@@ -235,7 +235,7 @@ abstract class ManyToManyRelationTest extends BaseTest
         $r->register($tagContext)->linkTable($tagContext, 'default', 'tag_context');
 
         (new Compiler())->compile($r, [
-            (new GenerateRelations(['manyToMany' => new ManyToMany()])),
+            new GenerateRelations(['manyToMany' => new ManyToMany()]),
             $t = new RenderTables(),
             new RenderRelations(),
         ]);
@@ -285,7 +285,7 @@ abstract class ManyToManyRelationTest extends BaseTest
         $r->register($tagContext)->linkTable($tagContext, 'default', 'tag_context');
 
         (new Compiler())->compile($r, [
-            (new GenerateRelations(['manyToMany' => new ManyToMany()])),
+            new GenerateRelations(['manyToMany' => new ManyToMany()]),
             $t = new RenderTables(),
             new RenderRelations(),
         ]);

--- a/tests/Schema/Relation/ManyToManyRelationTest.php
+++ b/tests/Schema/Relation/ManyToManyRelationTest.php
@@ -53,7 +53,7 @@ abstract class ManyToManyRelationTest extends BaseTest
     public function testThrowAnExceptionWhenPkNotDefinedInSource(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Entity `post` must have defined primary key');
+        $this->expectExceptionMessage('Entity `post` must have defined primary key');
 
         $post = Post::defineWithoutPK();
         $tag = Tag::define();
@@ -78,7 +78,7 @@ abstract class ManyToManyRelationTest extends BaseTest
     public function testThrowAnExceptionWhenPkNotDefinedInTarget(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Entity `tag` must have defined primary key');
+        $this->expectExceptionMessage('Entity `tag` must have defined primary key');
 
         $post = Post::define();
         $tag = Tag::defineWithoutPK();
@@ -399,5 +399,37 @@ abstract class ManyToManyRelationTest extends BaseTest
             'tagContext',
             $schema['tag'][Schema::RELATIONS]['posts'][Relation::SCHEMA][Relation::THROUGH_ENTITY]
         );
+    }
+
+    public function testRenderWithIndex(): void
+    {
+        $post = Post::define();
+        $tag = Tag::define();
+        $tagContext = TagContext::define();
+
+        $post->getRelations()->remove('author');
+
+        $post->getRelations()->set('tags', new RelationDefinition());
+        $post->getRelations()->get('tags')
+            ->setType('manyToMany')
+            ->setTarget('tag')
+            ->getOptions()->set('through', 'tagContext');
+
+        $r = new Registry($this->dbal);
+        $r->register($post)->linkTable($post, 'default', 'post');
+        $r->register($tag)->linkTable($tag, 'default', 'tag');
+        $r->register($tagContext)->linkTable($tagContext, 'default', 'tag_context');
+
+        (new Compiler())->compile($r, [
+            new GenerateRelations(['manyToMany' => new ManyToMany()]),
+            $t = new RenderTables(),
+            new RenderRelations(),
+        ]);
+
+        $t->getReflector()->run();
+
+        $table = $this->getDriver()->getSchema('tag_context');
+        $this->assertTrue($table->hasIndex(['tag_p_id']));
+        $this->assertTrue($table->hasIndex(['post_p_id']));
     }
 }

--- a/tests/Schema/Relation/RefersToRelationCompositePKTest.php
+++ b/tests/Schema/Relation/RefersToRelationCompositePKTest.php
@@ -63,7 +63,7 @@ abstract class RefersToRelationCompositePKTest extends BaseTest
     public function testInconsistentAmountOfPKsShouldThrowAndException(): void
     {
         $this->expectException(RegistryException::class);
-        $this->expectErrorMessage('Inconsistent amount of related fields. '
+        $this->expectExceptionMessage('Inconsistent amount of related fields. '
             . 'Source entity: `author`; keys: `id`, `slug`. Target entity: `post`; keys: `parent_id`.');
 
         $e = Post::defineCompositePK();


### PR DESCRIPTION
- [x] Waiting for https://github.com/cycle/database/pull/119

https://github.com/cycle/database/issues/113

#### Other changes

Replaced the deprecated method **expectErrorMessage** with the method **expectExceptionMessage**.