### PR TITLE
Add support for generated fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=8.0",
-    "cycle/orm": "^2.0",
+    "cycle/orm": "^2.7",
     "cycle/database": "^2.7.1",
     "yiisoft/friendly-exception": "^1.1"
   },

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -84,6 +84,7 @@ final class Compiler
             Schema::FIND_BY_KEYS => $this->renderReferences($entity),
             Schema::TYPECAST => $this->renderTypecast($entity),
             Schema::RELATIONS => [],
+            Schema::GENERATED_FIELDS => $this->renderGeneratedFields($entity),
         ];
 
         // For table inheritance we need to fill specific schema segments
@@ -182,6 +183,18 @@ final class Compiler
         $schema = [];
         foreach ($entity->getFields() as $name => $field) {
             $schema[$name] = $field->getColumn();
+        }
+
+        return $schema;
+    }
+
+    private function renderGeneratedFields(Entity $entity): array
+    {
+        $schema = [];
+        foreach ($entity->getFields() as $name => $field) {
+            if ($field->getGenerated() !== null) {
+                $schema[$name] = $field->getGenerated();
+            }
         }
 
         return $schema;

--- a/src/Definition/Field.php
+++ b/src/Definition/Field.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Definition;
 
-use Cycle\ORM\SchemaInterface;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\Schema\Definition\Map\OptionMap;
 use Cycle\Schema\Exception\FieldException;
 
@@ -142,7 +142,7 @@ final class Field
     }
 
     /**
-     * @param int|null $type Generating type {@see SchemaInterface::GENERATED_*} constants.
+     * @param int|null $type Generating type {@see GeneratedField*} constants.
      */
     public function setGenerated(int|null $type): self
     {

--- a/src/Definition/Field.php
+++ b/src/Definition/Field.php
@@ -33,9 +33,6 @@ final class Field
      */
     private array|string|null $typecast = null;
 
-    /**
-     * @var positive-int|null
-     */
     private ?int $generated = null;
 
     private bool $referenced = false;
@@ -145,7 +142,7 @@ final class Field
     }
 
     /**
-     * @param positive-int|null $type. Generating type {@see SchemaInterface::GENERATED_*} constants.
+     * @param int|null $type Generating type {@see SchemaInterface::GENERATED_*} constants.
      */
     public function setGenerated(int|null $type): self
     {
@@ -154,9 +151,6 @@ final class Field
         return $this;
     }
 
-    /**
-     * @return positive-int|null
-     */
     public function getGenerated(): ?int
     {
         return $this->generated;

--- a/src/Definition/Field.php
+++ b/src/Definition/Field.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Definition;
 
+use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Definition\Map\OptionMap;
 use Cycle\Schema\Exception\FieldException;
 
@@ -31,6 +32,11 @@ final class Field
      * @var callable-array|string|null
      */
     private array|string|null $typecast = null;
+
+    /**
+     * @var positive-int|null
+     */
+    private ?int $generated = null;
 
     private bool $referenced = false;
     private ?string $entityClass = null;
@@ -136,6 +142,24 @@ final class Field
     public function getTypecast(): array|string|null
     {
         return $this->typecast;
+    }
+
+    /**
+     * @param positive-int|null $type. Generating type {@see SchemaInterface::GENERATED_*} constants.
+     */
+    public function setGenerated(int|null $type): self
+    {
+        $this->generated = $type;
+
+        return $this;
+    }
+
+    /**
+     * @return positive-int|null
+     */
+    public function getGenerated(): ?int
+    {
+        return $this->generated;
     }
 
     public function setReferenced(bool $indexed): self

--- a/tests/Schema/CompilerTest.php
+++ b/tests/Schema/CompilerTest.php
@@ -6,6 +6,7 @@ namespace Cycle\Schema\Tests;
 
 use Cycle\Database\DatabaseProviderInterface;
 use Cycle\ORM\Parser\Typecast;
+use Cycle\ORM\Schema\GeneratedField;
 use Cycle\ORM\SchemaInterface;
 use Cycle\Schema\Compiler;
 use Cycle\Schema\Definition\Entity;
@@ -18,7 +19,7 @@ use Cycle\Schema\Tests\Fixtures\BrokenSchemaModifier;
 use Cycle\Schema\Tests\Fixtures\Typecaster;
 use PHPUnit\Framework\TestCase;
 
-class CompilerTest extends TestCase
+final class CompilerTest extends TestCase
 {
     public function testWrongGeneratorShouldThrowAnException(): void
     {
@@ -97,21 +98,21 @@ class CompilerTest extends TestCase
             (new Field())
             ->setType('datetime')
             ->setColumn('created_at')
-            ->setGenerated(SchemaInterface::GENERATED_PHP_INSERT)
+            ->setGenerated(GeneratedField::BEFORE_INSERT)
         );
         $entity->getFields()->set(
             'updatedAt',
             (new Field())
             ->setType('datetime')
             ->setColumn('created_at')
-            ->setGenerated(SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE)
+            ->setGenerated(GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE)
         );
         $entity->getFields()->set(
             'sequence',
             (new Field())
             ->setType('serial')
             ->setColumn('some_sequence')
-            ->setGenerated(SchemaInterface::GENERATED_DB)
+            ->setGenerated(GeneratedField::ON_INSERT)
         );
 
         $r = new Registry($this->createMock(DatabaseProviderInterface::class));
@@ -120,9 +121,9 @@ class CompilerTest extends TestCase
         $schema = (new Compiler())->compile($r);
 
         $this->assertSame([
-            'createdAt' => SchemaInterface::GENERATED_PHP_INSERT,
-            'updatedAt' => SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE,
-            'sequence' => SchemaInterface::GENERATED_DB,
+            'createdAt' => GeneratedField::BEFORE_INSERT,
+            'updatedAt' => GeneratedField::BEFORE_INSERT | GeneratedField::BEFORE_UPDATE,
+            'sequence' => GeneratedField::ON_INSERT,
         ], $schema['author'][SchemaInterface::GENERATED_FIELDS]);
     }
 

--- a/tests/Schema/CompilerTest.php
+++ b/tests/Schema/CompilerTest.php
@@ -92,17 +92,23 @@ class CompilerTest extends TestCase
         $entity->setRole('author')->setClass(Author::class);
         $entity->getFields()->set('id', (new Field())->setType('primary')->setColumn('id'));
         $entity->getFields()->set('name', (new Field())->setType('string')->setColumn('name'));
-        $entity->getFields()->set('createdAt', (new Field())
+        $entity->getFields()->set(
+            'createdAt',
+            (new Field())
             ->setType('datetime')
             ->setColumn('created_at')
             ->setGenerated(SchemaInterface::GENERATED_PHP_INSERT)
         );
-        $entity->getFields()->set('updatedAt', (new Field())
+        $entity->getFields()->set(
+            'updatedAt',
+            (new Field())
             ->setType('datetime')
             ->setColumn('created_at')
             ->setGenerated(SchemaInterface::GENERATED_PHP_INSERT | SchemaInterface::GENERATED_PHP_UPDATE)
         );
-        $entity->getFields()->set('sequence', (new Field())
+        $entity->getFields()->set(
+            'sequence',
+            (new Field())
             ->setType('serial')
             ->setColumn('some_sequence')
             ->setGenerated(SchemaInterface::GENERATED_DB)

--- a/tests/Schema/Generator/TableGeneratorTest.php
+++ b/tests/Schema/Generator/TableGeneratorTest.php
@@ -67,6 +67,7 @@ abstract class TableGeneratorTest extends BaseTest
                 Schema::TYPECAST => [],
                 Schema::SCHEMA => [],
                 Schema::TYPECAST_HANDLER => [Typecaster::class, 'default_typecaster'],
+                Schema::GENERATED_FIELDS => [],
             ],
         ], $schema);
     }
@@ -103,6 +104,7 @@ abstract class TableGeneratorTest extends BaseTest
                 Schema::TYPECAST => [],
                 Schema::SCHEMA => [],
                 Schema::TYPECAST_HANDLER => [Typecaster::class],
+                Schema::GENERATED_FIELDS => [],
             ],
         ], $schema);
     }
@@ -171,6 +173,7 @@ abstract class TableGeneratorTest extends BaseTest
                 Schema::TYPECAST_HANDLER => [
                     Typecaster::class,
                 ],
+                Schema::GENERATED_FIELDS => [],
             ],
         ], $c->getSchema());
     }
@@ -203,6 +206,7 @@ abstract class TableGeneratorTest extends BaseTest
                 Schema::TYPECAST => [],
                 Schema::SCHEMA => [],
                 Schema::TYPECAST_HANDLER => null,
+                Schema::GENERATED_FIELDS => [],
             ],
         ], $c->getSchema());
     }


### PR DESCRIPTION
## What was changed

Added support for `GENERATED_FIELDS` in the schema, which will be in the next version of Cycle ORM

## Checklist

- [x] https://github.com/cycle/orm/pull/462