### PR TITLE
Use schema modifiers as mutable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,11 @@
       "Cycle\\Schema\\": "src/"
     }
   },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "2.9.x-dev"
+    }
+  },
   "autoload-dev": {
     "psr-4": {
       "Cycle\\Schema\\Tests\\": "tests/Schema/"

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -123,6 +123,7 @@ final class Compiler
 
         // Apply modifiers
         foreach ($entity->getSchemaModifiers() as $modifier) {
+            \assert($modifier instanceof SchemaModifierInterface);
             try {
                 $modifier->modifySchema($schema);
             } catch (Throwable $e) {

--- a/src/Definition/Entity.php
+++ b/src/Definition/Entity.php
@@ -252,9 +252,9 @@ final class Entity
 
     public function addSchemaModifier(SchemaModifierInterface $modifier): self
     {
-        $this->schemaModifiers[] = $this->role === null
-            ? $modifier
-            : $modifier->withRole($this->role);
+        $this->role ?? throw new EntityException("Entity must have a `role` to be able to add a modifier.");
+
+        $this->schemaModifiers[] = $modifier->withRole($this->role);
 
         return $this;
     }

--- a/src/Definition/Entity.php
+++ b/src/Definition/Entity.php
@@ -252,7 +252,10 @@ final class Entity
 
     public function addSchemaModifier(SchemaModifierInterface $modifier): self
     {
-        $this->schemaModifiers[] = $modifier->withRole($this->role);
+        $this->schemaModifiers[] = $this->role === null
+            ? $modifier
+            : $modifier->withRole($this->role);
+
         return $this;
     }
 

--- a/src/Definition/Entity.php
+++ b/src/Definition/Entity.php
@@ -252,7 +252,7 @@ final class Entity
 
     public function addSchemaModifier(SchemaModifierInterface $modifier): self
     {
-        $this->schemaModifiers[] = $modifier;
+        $this->schemaModifiers[] = $modifier->withRole($this->role);
         return $this;
     }
 
@@ -261,7 +261,6 @@ final class Entity
      */
     public function getSchemaModifiers(): \Traversable
     {
-        // yield from $this->getRelations();
         yield from $this->schemaModifiers;
     }
 

--- a/src/Definition/Entity.php
+++ b/src/Definition/Entity.php
@@ -252,7 +252,7 @@ final class Entity
 
     public function addSchemaModifier(SchemaModifierInterface $modifier): self
     {
-        $this->role ?? throw new EntityException("Entity must have a `role` to be able to add a modifier.");
+        $this->role ?? throw new EntityException('Entity must have a `role` to be able to add a modifier.');
 
         $this->schemaModifiers[] = $modifier->withRole($this->role);
 

--- a/src/Definition/Entity.php
+++ b/src/Definition/Entity.php
@@ -252,9 +252,9 @@ final class Entity
 
     public function addSchemaModifier(SchemaModifierInterface $modifier): self
     {
-        $this->role ?? throw new EntityException('Entity must have a `role` to be able to add a modifier.');
-
-        $this->schemaModifiers[] = $modifier->withRole($this->role);
+        $this->schemaModifiers[] = $modifier->withRole($this->role ?? throw new EntityException(
+            'Entity must have a `role` to be able to add a modifier.'
+        ));
 
         return $this;
     }

--- a/src/Generator/GenerateModifiers.php
+++ b/src/Generator/GenerateModifiers.php
@@ -28,7 +28,7 @@ final class GenerateModifiers implements GeneratorInterface
     protected function register(Registry $registry, Entity $entity): void
     {
         $role = $entity->getRole();
-
+        assert($role !== null);
         foreach ($entity->getSchemaModifiers() as $modifier) {
             \assert($modifier instanceof SchemaModifierInterface);
             try {

--- a/src/Generator/GenerateModifiers.php
+++ b/src/Generator/GenerateModifiers.php
@@ -28,11 +28,11 @@ final class GenerateModifiers implements GeneratorInterface
     protected function register(Registry $registry, Entity $entity): void
     {
         $role = $entity->getRole();
-        assert($role !== null);
+
         foreach ($entity->getSchemaModifiers() as $modifier) {
             \assert($modifier instanceof SchemaModifierInterface);
             try {
-                $modifier->withRole($role)->compute($registry);
+                $modifier->compute($registry);
             } catch (SchemaModifierException $e) {
                 throw new SchemaException(
                     sprintf('Unable to compute modifier `%s` for the `%s` role.', $modifier::class, $role),

--- a/src/Generator/RenderModifiers.php
+++ b/src/Generator/RenderModifiers.php
@@ -28,11 +28,11 @@ final class RenderModifiers implements GeneratorInterface
     protected function register(Registry $registry, Entity $entity): void
     {
         $role = $entity->getRole();
-        assert($role !== null);
+
         foreach ($entity->getSchemaModifiers() as $modifier) {
             \assert($modifier instanceof SchemaModifierInterface);
             try {
-                $modifier->withRole($role)->render($registry);
+                $modifier->render($registry);
             } catch (SchemaModifierException $e) {
                 throw new SchemaException(
                     sprintf('Unable to render modifier `%s` for the `%s` role.', $modifier::class, $role),

--- a/src/Generator/RenderModifiers.php
+++ b/src/Generator/RenderModifiers.php
@@ -28,7 +28,7 @@ final class RenderModifiers implements GeneratorInterface
     protected function register(Registry $registry, Entity $entity): void
     {
         $role = $entity->getRole();
-
+        assert($role !== null);
         foreach ($entity->getSchemaModifiers() as $modifier) {
             \assert($modifier instanceof SchemaModifierInterface);
             try {

--- a/tests/Schema/EntityTest.php
+++ b/tests/Schema/EntityTest.php
@@ -305,24 +305,25 @@ class EntityTest extends TestCase
 
     public function testSchemaModifierWithRole(): void
     {
-        $mock = $this->createMock(SchemaModifierInterface::class);
-        $mock->expects($this->once())->method('withRole')->with('my-entity')->willReturnSelf();
+        $modifier = $this->createMock(SchemaModifierInterface::class);
+        $modifier->expects($this->once())->method('withRole')->with('my-entity')->willReturnSelf();
 
         $e = new Entity();
         $e->setRole('my-entity');
-        $e->addSchemaModifier($modifier = $mock);
+        $e->addSchemaModifier($modifier);
 
         $this->assertSame([$modifier], iterator_to_array($e->getSchemaModifiers()));
     }
 
     public function testSchemaModifier(): void
     {
-        $mock = $this->createMock(SchemaModifierInterface::class);
-
+        $modifier = $this->createMock(SchemaModifierInterface::class);
         $e = new Entity();
-        $e->addSchemaModifier($modifier = $mock);
 
-        $this->assertSame([$modifier], iterator_to_array($e->getSchemaModifiers()));
+        $this->expectException(EntityException::class);
+        $this->expectExceptionMessage("Entity must have a `role` to be able to add a modifier.");
+
+        $e->addSchemaModifier($modifier);
     }
 
     public function testMergeTwoEntities(): void

--- a/tests/Schema/EntityTest.php
+++ b/tests/Schema/EntityTest.php
@@ -321,7 +321,7 @@ class EntityTest extends TestCase
         $e = new Entity();
 
         $this->expectException(EntityException::class);
-        $this->expectExceptionMessage("Entity must have a `role` to be able to add a modifier.");
+        $this->expectExceptionMessage('Entity must have a `role` to be able to add a modifier.');
 
         $e->addSchemaModifier($modifier);
     }

--- a/tests/Schema/EntityTest.php
+++ b/tests/Schema/EntityTest.php
@@ -303,10 +303,24 @@ class EntityTest extends TestCase
         $this->assertSame($inheritance, $e->getInheritance());
     }
 
+    public function testSchemaModifierWithRole(): void
+    {
+        $mock = $this->createMock(SchemaModifierInterface::class);
+        $mock->expects($this->once())->method('withRole')->with('my-entity')->willReturnSelf();
+
+        $e = new Entity();
+        $e->setRole('my-entity');
+        $e->addSchemaModifier($modifier = $mock);
+
+        $this->assertSame([$modifier], iterator_to_array($e->getSchemaModifiers()));
+    }
+
     public function testSchemaModifier(): void
     {
+        $mock = $this->createMock(SchemaModifierInterface::class);
+
         $e = new Entity();
-        $e->addSchemaModifier($modifier = $this->createMock(SchemaModifierInterface::class));
+        $e->addSchemaModifier($modifier = $mock);
 
         $this->assertSame([$modifier], iterator_to_array($e->getSchemaModifiers()));
     }

--- a/tests/Schema/Generator/GenerateModifiersTest.php
+++ b/tests/Schema/Generator/GenerateModifiersTest.php
@@ -98,7 +98,6 @@ class GenerateModifiersTest extends TestCase
     public function brokenMethodsDataProvider()
     {
         return [
-            'withRole' => ['withRole'],
             'compute' => ['compute'],
         ];
     }

--- a/tests/Schema/Generator/RenderModifiersTest.php
+++ b/tests/Schema/Generator/RenderModifiersTest.php
@@ -28,12 +28,10 @@ class RenderModifiersTest extends TestCase
         $user->setRole('user')->setClass(User::class);
         $user->getFields()->set('foo_bar', (new Field())->setType('primary')->setColumn('id'));
 
-        $user->addSchemaModifier($mock = $this->createMock(SchemaModifierInterface::class));
-        $mock
-            ->expects($this->atLeastOnce())
-            ->method('withRole')
-            ->with($this->equalTo('user'))
-            ->willReturn($mock);
+        $mock = $this->createMock(SchemaModifierInterface::class);
+        $mock->expects(self::once())->method('withRole')->with('user')->willReturnSelf();
+
+        $user->addSchemaModifier($mock);
 
         $mock
             ->expects($this->atLeastOnce())
@@ -73,7 +71,7 @@ class RenderModifiersTest extends TestCase
     public function brokenMethodsDataProvider()
     {
         return [
-            'withRole' => ['withRole'],
+            // 'withRole' => ['withRole'],
             'render' => ['render'],
         ];
     }

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       SA_PASSWORD: "SSpaSS__1"
       ACCEPT_EULA: "Y"
 
-  mysql_latest:
-    image: mysql:latest
+  mysql:
+    image: mysql:8.0.37
     restart: always
     command: --default-authentication-plugin=mysql_native_password
     ports:


### PR DESCRIPTION
<!-- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR!
If it is a significant code change, please **make sure there is an open issue** for this.
We work best with you when we have accepted the idea first before you code. -->

## 🔍 What was changed

Call modifier's `withRole()` method at the same moment when they are added into Entity definition.\
An exception will be thrown when a modifier is added to an entity without role

## 🤔 Why?

To not to rewrite all the stateful behaviors

## 📝 Checklist

<!--- add/delete as needed --->

- Closes https://github.com/cycle/entity-behavior/issues/33
- How was this tested:
  - [x] Tested manually
  - [x] Unit tests added
