### PR TITLE
Add typecast to string in the ORM schema

### DIFF
--- a/src/Generator/GenerateTypecast.php
+++ b/src/Generator/GenerateTypecast.php
@@ -73,6 +73,10 @@ final class GenerateTypecast implements GeneratorInterface
             return 'datetime';
         }
 
+        if ($column->getType() === AbstractColumn::STRING) {
+            return 'string';
+        }
+
         return null;
     }
 }

--- a/tests/Schema/Generator/TypecastGeneratorTest.php
+++ b/tests/Schema/Generator/TypecastGeneratorTest.php
@@ -28,6 +28,7 @@ abstract class TypecastGeneratorTest extends BaseTest
         $this->assertSame('int', $schema['user'][Schema::TYPECAST]['p_id']);
         $this->assertSame('float', $schema['user'][Schema::TYPECAST]['p_balance']);
         $this->assertSame('datetime', $schema['user'][Schema::TYPECAST]['p_created_at']);
+        $this->assertSame('string', $schema['user'][Schema::TYPECAST]['p_name']);
 
         $this->assertTrue(in_array($schema['user'][Schema::TYPECAST]['p_id'], ['int', 'bool']));
     }


### PR DESCRIPTION
By default, all fields with the string type are skipped and not passed to Typecast. This MR fixes it