### PR TITLE
Load table schemas lazily and in bulk in Registry

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": ">=8.1",
         "cycle/orm": "^2.18",
-        "cycle/database": "^2.20",
+        "cycle/database": "^2.23",
         "yiisoft/friendly-exception": "^1.1"
     },
     "require-dev": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -370,32 +370,20 @@
       <code><![CDATA[public function getIterator(): \Traversable]]></code>
     </MissingOverrideAttribute>
     <MixedArrayAccess>
-      <code><![CDATA[$association['database']]]></code>
-      <code><![CDATA[$association['schema']]]></code>
-      <code><![CDATA[$association['table']]]></code>
       <code><![CDATA[$this->relations[$entity][$name]]]></code>
-      <code><![CDATA[$this->tables[$entity]['database']]]></code>
-      <code><![CDATA[$this->tables[$entity]['schema']]]></code>
-      <code><![CDATA[$this->tables[$entity]['table']]]></code>
     </MixedArrayAccess>
     <MixedArrayAssignment>
       <code><![CDATA[$children[]]]></code>
       <code><![CDATA[$relations[$name]]]></code>
     </MixedArrayAssignment>
     <MixedAssignment>
-      <code><![CDATA[$association]]></code>
       <code><![CDATA[$children]]></code>
       <code><![CDATA[$relations]]></code>
-      <code><![CDATA[$schema]]></code>
-      <code><![CDATA[$schema]]></code>
     </MixedAssignment>
     <MixedReturnStatement>
       <code><![CDATA[$this->children[$entity]]]></code>
       <code><![CDATA[$this->relations[$entity]]]></code>
       <code><![CDATA[$this->relations[$entity][$name]]]></code>
-      <code><![CDATA[$this->tables[$entity]['database']]]></code>
-      <code><![CDATA[$this->tables[$entity]['schema']]]></code>
-      <code><![CDATA[$this->tables[$entity]['table']]]></code>
     </MixedReturnStatement>
     <PossiblyUnusedMethod>
       <code><![CDATA[__construct]]></code>

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -20,7 +20,15 @@ final class Registry implements \IteratorAggregate
     private array $entities = [];
 
     private DatabaseProviderInterface $dbal;
+
+    /**
+     * @var \SplObjectStorage<
+     *     Entity,
+     *     array{database: string, table: non-empty-string, schema: AbstractTable|null}|null
+     * >
+     */
     private \SplObjectStorage $tables;
+
     private \SplObjectStorage $children;
     private \SplObjectStorage $relations;
     private Defaults $defaults;
@@ -143,33 +151,12 @@ final class Registry implements \IteratorAggregate
 
         $database = $this->dbal->database($database)->getName();
 
-        $schema = null;
-        foreach ($this->tables as $other) {
-            $association = $this->tables[$other];
-
-            if ($association === null) {
-                continue;
-            }
-
-            // avoid schema duplication
-            if ($association['database'] === $database && $association['table'] === $table) {
-                $schema = $association['schema'];
-                break;
-            }
-        }
-
-        if ($schema === null) {
-            $dbTable = $this->dbal->database($database)->table($table);
-            if (!\method_exists($dbTable, 'getSchema')) {
-                throw new RegistryException('Unable to retrieve table schema.');
-            }
-            $schema = $dbTable->getSchema();
-        }
-
+        // Table schemas are loaded lazily and in bulk: by the time the first schema is requested
+        // all the linked tables are known, so the whole set costs a constant number of queries.
         $this->tables[$entity] = [
             'database' => $database,
             'table' => $table,
-            'schema' => $schema,
+            'schema' => null,
         ];
 
         return $this;
@@ -192,11 +179,7 @@ final class Registry implements \IteratorAggregate
      */
     public function getDatabase(Entity $entity): string
     {
-        if (!$this->hasTable($entity)) {
-            throw new RegistryException("Entity `{$entity->getRole()}` has no assigned table");
-        }
-
-        return $this->tables[$entity]['database'];
+        return $this->getTableAssociation($entity)['database'];
     }
 
     /**
@@ -206,11 +189,7 @@ final class Registry implements \IteratorAggregate
      */
     public function getTable(Entity $entity): string
     {
-        if (!$this->hasTable($entity)) {
-            throw new RegistryException("Entity `{$entity->getRole()}` has no assigned table");
-        }
-
-        return $this->tables[$entity]['table'];
+        return $this->getTableAssociation($entity)['table'];
     }
 
     /**
@@ -218,11 +197,15 @@ final class Registry implements \IteratorAggregate
      */
     public function getTableSchema(Entity $entity): AbstractTable
     {
-        if (!$this->hasTable($entity)) {
-            throw new RegistryException("Entity `{$entity->getRole()}` has no assigned table");
+        $schema = $this->getTableAssociation($entity)['schema'];
+
+        if ($schema === null) {
+            $this->loadTableSchemas();
+            $schema = $this->getTableAssociation($entity)['schema'];
+            \assert($schema !== null);
         }
 
-        return $this->tables[$entity]['schema'];
+        return $schema;
     }
 
     /**
@@ -285,5 +268,88 @@ final class Registry implements \IteratorAggregate
     protected function hasInstance(Entity $entity): bool
     {
         return array_search($entity, $this->entities, true) !== false;
+    }
+
+    /**
+     * @return array{database: string, table: non-empty-string, schema: AbstractTable|null}
+     *
+     * @throws RegistryException
+     */
+    private function getTableAssociation(Entity $entity): array
+    {
+        if (!$this->hasInstance($entity)) {
+            throw new RegistryException("Undefined entity `{$entity->getRole()}`");
+        }
+
+        $association = $this->tables[$entity];
+
+        if ($association === null) {
+            throw new RegistryException("Entity `{$entity->getRole()}` has no assigned table");
+        }
+
+        return $association;
+    }
+
+    /**
+     * Load schemas for all the linked tables that don't have one yet. Entities sharing the same
+     * database and table receive the same {@see AbstractTable} instance.
+     *
+     * @throws RegistryException
+     * @throws DBALException
+     */
+    private function loadTableSchemas(): void
+    {
+        /** @var array<string, array<non-empty-string, AbstractTable>> $loaded */
+        $loaded = [];
+        /** @var array<string, array<non-empty-string, true>> $pending */
+        $pending = [];
+        foreach ($this->tables as $entity) {
+            $association = $this->tables[$entity];
+            if ($association === null) {
+                continue;
+            }
+
+            if ($association['schema'] !== null) {
+                $loaded[$association['database']][$association['table']] = $association['schema'];
+            } else {
+                $pending[$association['database']][$association['table']] = true;
+            }
+        }
+
+        foreach ($pending as $database => $tables) {
+            // avoid schema duplication
+            $names = \array_keys(\array_diff_key($tables, $loaded[$database] ?? []));
+            if ($names === []) {
+                continue;
+            }
+
+            $db = $this->dbal->database($database);
+            if (\method_exists($db, 'getSchemas')) {
+                /** @var array<non-empty-string, AbstractTable> $schemas */
+                $schemas = $db->getSchemas($names);
+                $loaded[$database] = ($loaded[$database] ?? []) + $schemas;
+                continue;
+            }
+
+            foreach ($names as $name) {
+                $dbTable = $db->table($name);
+                if (!\method_exists($dbTable, 'getSchema')) {
+                    throw new RegistryException('Unable to retrieve table schema.');
+                }
+                /** @var AbstractTable $schema */
+                $schema = $dbTable->getSchema();
+                $loaded[$database][$name] = $schema;
+            }
+        }
+
+        foreach ($this->tables as $entity) {
+            $association = $this->tables[$entity];
+            if ($association === null || $association['schema'] !== null) {
+                continue;
+            }
+
+            $association['schema'] = $loaded[$association['database']][$association['table']];
+            $this->tables[$entity] = $association;
+        }
     }
 }

--- a/tests/Schema/Fixtures/LegacyDatabase.php
+++ b/tests/Schema/Fixtures/LegacyDatabase.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Schema\Tests\Fixtures;
+
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Query\DeleteQuery;
+use Cycle\Database\Query\InsertQuery;
+use Cycle\Database\Query\SelectQuery;
+use Cycle\Database\Query\UpdateQuery;
+use Cycle\Database\StatementInterface;
+use Cycle\Database\TableInterface;
+
+/**
+ * Emulates a cycle/database version without the bulk `getSchemas()` method to exercise the
+ * per-table fallback of the Registry. Only the methods the Registry touches are functional.
+ */
+class LegacyDatabase implements DatabaseInterface, DatabaseProviderInterface
+{
+    public function __construct(
+        private DatabaseInterface $database,
+        private bool $bareTables = false,
+    ) {}
+
+    public function database(?string $database = null): DatabaseInterface
+    {
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->database->getName();
+    }
+
+    public function table(string $name): TableInterface
+    {
+        if ($this->bareTables) {
+            return new LegacyTable($this->database->table($name));
+        }
+
+        return $this->database->table($name);
+    }
+
+    public function getType(): string
+    {
+        return $this->database->getType();
+    }
+
+    public function getDriver(int $type = self::WRITE): DriverInterface
+    {
+        return $this->database->getDriver($type);
+    }
+
+    public function withPrefix(string $prefix, bool $add = true): DatabaseInterface
+    {
+        throw new \BadMethodCallException(__METHOD__ . ' is not expected to be called');
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->database->getPrefix();
+    }
+
+    public function hasTable(string $name): bool
+    {
+        return $this->database->hasTable($name);
+    }
+
+    public function getTables(): array
+    {
+        return $this->database->getTables();
+    }
+
+    public function execute(string $query, array $parameters = []): int
+    {
+        return $this->database->execute($query, $parameters);
+    }
+
+    public function query(string $query, array $parameters = []): StatementInterface
+    {
+        return $this->database->query($query, $parameters);
+    }
+
+    public function insert(string $table = ''): InsertQuery
+    {
+        return $this->database->insert($table);
+    }
+
+    public function update(string $table = '', array $values = [], array $where = []): UpdateQuery
+    {
+        return $this->database->update($table, $values, $where);
+    }
+
+    public function delete(string $table = '', array $where = []): DeleteQuery
+    {
+        return $this->database->delete($table, $where);
+    }
+
+    public function select(mixed $columns = '*'): SelectQuery
+    {
+        return $this->database->select($columns);
+    }
+
+    public function transaction(callable $callback, ?string $isolationLevel = null): mixed
+    {
+        return $this->database->transaction($callback, $isolationLevel);
+    }
+
+    public function begin(?string $isolationLevel = null): bool
+    {
+        return $this->database->begin($isolationLevel);
+    }
+
+    public function commit(): bool
+    {
+        return $this->database->commit();
+    }
+
+    public function rollback(): bool
+    {
+        return $this->database->rollback();
+    }
+}

--- a/tests/Schema/Fixtures/LegacyTable.php
+++ b/tests/Schema/Fixtures/LegacyTable.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Schema\Tests\Fixtures;
+
+use Cycle\Database\TableInterface;
+
+/**
+ * A table implementation without the `getSchema()` method — the Registry must refuse it with a
+ * clear exception instead of failing on an undefined method call.
+ */
+class LegacyTable implements TableInterface
+{
+    public function __construct(
+        private TableInterface $table,
+    ) {}
+
+    public function exists(): bool
+    {
+        return $this->table->exists();
+    }
+
+    public function getName(): string
+    {
+        return $this->table->getName();
+    }
+
+    public function getFullName(): string
+    {
+        return $this->table->getFullName();
+    }
+
+    public function getPrimaryKeys(): array
+    {
+        return $this->table->getPrimaryKeys();
+    }
+
+    public function hasColumn(string $name): bool
+    {
+        return $this->table->hasColumn($name);
+    }
+
+    public function getColumns(): array
+    {
+        return $this->table->getColumns();
+    }
+
+    public function hasIndex(array $columns = []): bool
+    {
+        return $this->table->hasIndex($columns);
+    }
+
+    public function getIndexes(): array
+    {
+        return $this->table->getIndexes();
+    }
+
+    public function hasForeignKey(array $columns): bool
+    {
+        return $this->table->hasForeignKey($columns);
+    }
+
+    public function getForeignKeys(): array
+    {
+        return $this->table->getForeignKeys();
+    }
+
+    public function getDependencies(): array
+    {
+        return $this->table->getDependencies();
+    }
+}

--- a/tests/Schema/Fixtures/SpyDatabase.php
+++ b/tests/Schema/Fixtures/SpyDatabase.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Cycle\Schema\Tests\Fixtures;
+
+use Cycle\Database\DatabaseInterface;
+use Cycle\Database\DatabaseProviderInterface;
+use Cycle\Database\Driver\DriverInterface;
+use Cycle\Database\Query\DeleteQuery;
+use Cycle\Database\Query\InsertQuery;
+use Cycle\Database\Query\SelectQuery;
+use Cycle\Database\Query\UpdateQuery;
+use Cycle\Database\Schema\AbstractTable;
+use Cycle\Database\StatementInterface;
+use Cycle\Database\TableInterface;
+
+/**
+ * Wraps a real database and records every {@see self::getSchemas()} call so tests can assert the
+ * bulk-loading contract of the Registry: linking defers introspection, and the first schema request
+ * loads all the pending tables through a single batched call.
+ */
+class SpyDatabase implements DatabaseInterface, DatabaseProviderInterface
+{
+    /** @var list<non-empty-string[]> The table-name list of each getSchemas() call, in order. */
+    public array $getSchemasCalls = [];
+
+    public function __construct(
+        private DatabaseInterface $database,
+    ) {}
+
+    /**
+     * @param non-empty-string[]|null $tables
+     *
+     * @return array<non-empty-string, AbstractTable>
+     */
+    public function getSchemas(?array $tables = null): array
+    {
+        $this->getSchemasCalls[] = $tables;
+
+        return $this->database->getSchemas($tables);
+    }
+
+    public function database(?string $database = null): DatabaseInterface
+    {
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->database->getName();
+    }
+
+    public function table(string $name): TableInterface
+    {
+        return $this->database->table($name);
+    }
+
+    public function getType(): string
+    {
+        return $this->database->getType();
+    }
+
+    public function getDriver(int $type = self::WRITE): DriverInterface
+    {
+        return $this->database->getDriver($type);
+    }
+
+    public function withPrefix(string $prefix, bool $add = true): DatabaseInterface
+    {
+        throw new \BadMethodCallException(__METHOD__ . ' is not expected to be called');
+    }
+
+    public function getPrefix(): string
+    {
+        return $this->database->getPrefix();
+    }
+
+    public function hasTable(string $name): bool
+    {
+        return $this->database->hasTable($name);
+    }
+
+    public function getTables(): array
+    {
+        return $this->database->getTables();
+    }
+
+    public function execute(string $query, array $parameters = []): int
+    {
+        return $this->database->execute($query, $parameters);
+    }
+
+    public function query(string $query, array $parameters = []): StatementInterface
+    {
+        return $this->database->query($query, $parameters);
+    }
+
+    public function insert(string $table = ''): InsertQuery
+    {
+        return $this->database->insert($table);
+    }
+
+    public function update(string $table = '', array $values = [], array $where = []): UpdateQuery
+    {
+        return $this->database->update($table, $values, $where);
+    }
+
+    public function delete(string $table = '', array $where = []): DeleteQuery
+    {
+        return $this->database->delete($table, $where);
+    }
+
+    public function select(mixed $columns = '*'): SelectQuery
+    {
+        return $this->database->select($columns);
+    }
+
+    public function transaction(callable $callback, ?string $isolationLevel = null): mixed
+    {
+        return $this->database->transaction($callback, $isolationLevel);
+    }
+
+    public function begin(?string $isolationLevel = null): bool
+    {
+        return $this->database->begin($isolationLevel);
+    }
+
+    public function commit(): bool
+    {
+        return $this->database->commit();
+    }
+
+    public function rollback(): bool
+    {
+        return $this->database->rollback();
+    }
+}

--- a/tests/Schema/RegistryTest.php
+++ b/tests/Schema/RegistryTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Cycle\Schema\Tests;
 
+use Cycle\Database\Schema\AbstractTable;
 use Cycle\Schema\Compiler;
 use Cycle\Schema\Definition\Entity;
 use Cycle\Schema\Definition\Field;
 use Cycle\Schema\Exception\RegistryException;
 use Cycle\Schema\Registry;
 use Cycle\Schema\Tests\Fixtures\Author;
+use Cycle\Schema\Tests\Fixtures\LegacyDatabase;
 use Cycle\Schema\Tests\Fixtures\Post;
 use Cycle\Schema\Tests\Fixtures\User;
 
@@ -111,6 +113,99 @@ abstract class RegistryTest extends BaseTest
         $this->expectException(RegistryException::class);
 
         $r->getTableSchema(new Entity());
+    }
+
+    public function testGetTableNotLinked(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+        $r->register($e);
+
+        $this->expectException(RegistryException::class);
+        $this->expectExceptionMessage('Entity `user` has no assigned table');
+
+        $r->getTable($e);
+    }
+
+    public function testLinkTableDoesNotLoadSchema(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+        $r->register($e)->linkTable($e, 'default', 'user');
+
+        $this->assertTrue($r->hasTable($e));
+        $this->assertSame('default', $r->getDatabase($e));
+        $this->assertSame('user', $r->getTable($e));
+    }
+
+    public function testEntitiesOnSameTableShareSchema(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->register($e2)->linkTable($e2, 'default', 'user');
+
+        $this->assertSame($r->getTableSchema($e), $r->getTableSchema($e2));
+    }
+
+    public function testLateLinkedEntityReusesLoadedSchema(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+        $r->register($e)->linkTable($e, 'default', 'user');
+
+        // triggers the bulk load of every linked table
+        $schema = $r->getTableSchema($e);
+
+        // an entity linked after the load (embedded relations do this) must reuse the instance
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+        $r->register($e2)->linkTable($e2, 'default', 'user');
+
+        $this->assertSame($schema, $r->getTableSchema($e2));
+    }
+
+    public function testLinkTableWithoutGetSchemasSupport(): void
+    {
+        $r = new Registry(new LegacyDatabase($this->dbal->database('default')));
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->register($e2)->linkTable($e2, 'default', 'user');
+
+        $this->assertInstanceOf(AbstractTable::class, $r->getTableSchema($e));
+        $this->assertSame($r->getTableSchema($e), $r->getTableSchema($e2));
+    }
+
+    public function testLinkTableWithoutSchemaSupportThrowsAnException(): void
+    {
+        $r = new Registry(new LegacyDatabase($this->dbal->database('default'), bareTables: true));
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+        $r->register($e)->linkTable($e, 'default', 'user');
+
+        $this->expectException(RegistryException::class);
+        $this->expectExceptionMessage('Unable to retrieve table schema.');
+
+        $r->getTableSchema($e);
     }
 
     public function testRegisterChildNoEntity(): void

--- a/tests/Schema/RegistryTest.php
+++ b/tests/Schema/RegistryTest.php
@@ -13,6 +13,7 @@ use Cycle\Schema\Registry;
 use Cycle\Schema\Tests\Fixtures\Author;
 use Cycle\Schema\Tests\Fixtures\LegacyDatabase;
 use Cycle\Schema\Tests\Fixtures\Post;
+use Cycle\Schema\Tests\Fixtures\SpyDatabase;
 use Cycle\Schema\Tests\Fixtures\User;
 
 abstract class RegistryTest extends BaseTest
@@ -177,6 +178,119 @@ abstract class RegistryTest extends BaseTest
         $this->assertSame($schema, $r->getTableSchema($e2));
     }
 
+    public function testLinkTableDefersIntrospectionUntilFirstSchemaRequest(): void
+    {
+        $spy = new SpyDatabase($this->dbal->database('default'));
+        $r = new Registry($spy);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+
+        $e2 = new Entity();
+        $e2->setRole('post')->setClass(Post::class);
+
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->register($e2)->linkTable($e2, 'default', 'post');
+
+        // linking alone must not introspect anything
+        $this->assertSame([], $spy->getSchemasCalls);
+
+        // the first schema request loads every pending table in a single batched call
+        $r->getTableSchema($e);
+        $this->assertCount(1, $spy->getSchemasCalls);
+        $this->assertEqualsCanonicalizing(['user', 'post'], $spy->getSchemasCalls[0]);
+
+        // schemas for the other tables are already resolved, no further introspection
+        $r->getTableSchema($e2);
+        $this->assertCount(1, $spy->getSchemasCalls);
+    }
+
+    public function testLateLinkedTableTriggersOnlyOneAdditionalBatch(): void
+    {
+        $spy = new SpyDatabase($this->dbal->database('default'));
+        $r = new Registry($spy);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->getTableSchema($e);
+
+        $this->assertSame([['user']], $spy->getSchemasCalls);
+
+        // a table linked after the first load must be introspected on its own, and only it
+        $e2 = new Entity();
+        $e2->setRole('post')->setClass(Post::class);
+        $r->register($e2)->linkTable($e2, 'default', 'post');
+        $r->getTableSchema($e2);
+
+        $this->assertSame([['user'], ['post']], $spy->getSchemasCalls);
+    }
+
+    public function testBulkLoadResolvesDistinctTablesIndependently(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->register($e2)->linkTable($e2, 'default', 'post');
+
+        $userSchema = $r->getTableSchema($e);
+        $postSchema = $r->getTableSchema($e2);
+
+        $this->assertNotSame($userSchema, $postSchema);
+        $this->assertSame('user', $userSchema->getName());
+        $this->assertSame('post', $postSchema->getName());
+    }
+
+    public function testBulkLoadAcrossMultipleDatabases(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->register($e2)->linkTable($e2, 'secondary', 'user');
+
+        $defaultSchema = $r->getTableSchema($e);
+        $secondarySchema = $r->getTableSchema($e2);
+
+        $this->assertNotSame($defaultSchema, $secondarySchema);
+        $this->assertSame('default', $r->getDatabase($e));
+        $this->assertSame('secondary', $r->getDatabase($e2));
+    }
+
+    public function testBulkLoadDoesNotReloadAlreadyLoadedTable(): void
+    {
+        $r = new Registry($this->dbal);
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+        $r->register($e)->linkTable($e, 'default', 'user');
+
+        // triggers the first bulk load for 'user'
+        $userSchema = $r->getTableSchema($e);
+
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+        $r->register($e2)->linkTable($e2, 'default', 'post');
+
+        // triggers a second bulk load, only 'post' is pending this time
+        $postSchema = $r->getTableSchema($e2);
+
+        $this->assertNotSame($userSchema, $postSchema);
+        // the already loaded 'user' schema must not have been replaced/reloaded
+        $this->assertSame($userSchema, $r->getTableSchema($e));
+    }
+
     public function testLinkTableWithoutGetSchemasSupport(): void
     {
         $r = new Registry(new LegacyDatabase($this->dbal->database('default')));
@@ -192,6 +306,27 @@ abstract class RegistryTest extends BaseTest
 
         $this->assertInstanceOf(AbstractTable::class, $r->getTableSchema($e));
         $this->assertSame($r->getTableSchema($e), $r->getTableSchema($e2));
+    }
+
+    public function testLinkTableWithoutGetSchemasSupportResolvesDistinctTables(): void
+    {
+        $r = new Registry(new LegacyDatabase($this->dbal->database('default')));
+
+        $e = new Entity();
+        $e->setRole('user')->setClass(User::class);
+
+        $e2 = new Entity();
+        $e2->setRole('author')->setClass(Author::class);
+
+        $r->register($e)->linkTable($e, 'default', 'user');
+        $r->register($e2)->linkTable($e2, 'default', 'post');
+
+        $userSchema = $r->getTableSchema($e);
+        $postSchema = $r->getTableSchema($e2);
+
+        $this->assertNotSame($userSchema, $postSchema);
+        $this->assertSame('user', $userSchema->getName());
+        $this->assertSame('post', $postSchema->getName());
     }
 
     public function testLinkTableWithoutSchemaSupportThrowsAnException(): void


### PR DESCRIPTION
## 🔍 What was changed

- `Registry::linkTable()` no longer introspects the table immediately — it only records the database/table pair.
- The first `getTableSchema()` call loads every pending table per database through `Database::getSchemas()` (cycle/database#265): a constant number of catalog queries per database instead of a full introspection per table.
- On a cycle/database version without `getSchemas()` the Registry falls back to the old per-table path, so the behaviour is only faster, never different.

### How it works

- `linkTable()` stores `schema: null`; all linked tables stay pending until a schema is first requested.
- The first `getTableSchema()` groups pending tables by database and loads each group in one bulk call; entities sharing a table receive the same `AbstractTable` instance, missing tables come back as `STATUS_NEW` schemas.
- A table linked after the first load (embedded relations do this) reuses the already loaded instance; only genuinely new tables are fetched.

## Why?

Fixing cycle/orm#466: on a remote database with 60–100 ms round-trip latency, schema compilation of hundreds of entities takes minutes because each table is introspected separately. Benchmarked against Postgres with 200 tables (13 columns, 2 indexes, FK each): 1200 queries / 3.7 s per-table vs 6 queries / 0.6 s bulk; at 100 ms RTT that is ~2 minutes vs ~0.6 s.

One behavioural note: introspection errors now surface at the first `getTableSchema()` call instead of inside `linkTable()`.

## Checklist

- Requires cycle/database ^2.23 (cycle/database#265) for the bulk path; older versions work through the per-table fallback.
- How was this tested:
  - [x] Unit tests added (schema sharing, late link, per-table fallback via a `LegacyDatabase` fixture, error paths)
  - [x] Full suite run locally on SQLite (1017 tests), psalm and php-cs-fixer clean
  - [x] Bulk path benchmarked and verified for result identity against Postgres 12 (docker) with the cycle/database#265 branch